### PR TITLE
GDXDSD-1250 Removed filters for video.web in model

### DIFF
--- a/snowplow_web_block.model.lkml
+++ b/snowplow_web_block.model.lkml
@@ -39,7 +39,7 @@ explore: page_views {
   }
 
   fields: [ALL_FIELDS*,-page_views.last_page_title]
-  sql_always_where: ${page_url} NOT LIKE '%video.web.%' ;;
+  # sql_always_where: ${page_url} NOT LIKE '%video.web.%' ;; -- Causing problems with Dan's video analytics
   join: sessions {
     type: left_outer
     sql_on: ${sessions.session_id} = ${page_views.session_id};;
@@ -117,7 +117,7 @@ explore: sessions {
 }
 
 explore: users {
-  sql_always_where: ${first_page_url} NOT LIKE '%video.web.%' ;;
+  # sql_always_where: ${first_page_url} NOT LIKE '%video.web.%' ;; -- Causing problems with Dan's video analytics
 }
 
 explore: clicks{}


### PR DESCRIPTION
In the model there was a filter which was excluding results from video.web (.gov.bc.ca). This filter was commented out on lines 40 and 120.