### PR TITLE
date comparison for page_views; grouping flexible filters in sessions.

### DIFF
--- a/sessions.view.lkml
+++ b/sessions.view.lkml
@@ -154,6 +154,7 @@ view: sessions {
   }
 
   dimension: date_window {
+    group_label: "Flexible Filter"
     required_fields: [is_in_range]
     case: {
       when: {
@@ -176,6 +177,7 @@ view: sessions {
   # the last_period date range by. Exploring comparison_date with any Measure and a pivot
   # on date_window results in a pointwise comparison of current and last periods
   dimension: comparison_date {
+    group_label: "Flexible Filter"
     required_fields: [date_window]
     type: date
     sql:


### PR DESCRIPTION
Introduces the date comparison requirements for the `page_views` block; tested in explore linked in GDXDSD-1262.

Updates the Flexible Filter grouping on `date_window` and `comparison_date` in `sessions`.

@danpollock please review.